### PR TITLE
Add AMO metadata and publish automation

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -6,6 +6,16 @@ on:
   pull_request:
     branches: [ main, master ]
   workflow_dispatch:
+    inputs:
+      publish_to_amo:
+        description: Submit this version to addons.mozilla.org after packaging
+        required: false
+        default: false
+        type: boolean
+      release_notes:
+        description: Optional AMO release notes for this version
+        required: false
+        type: string
 
 jobs:
   package:
@@ -55,6 +65,46 @@ jobs:
       with:
         name: firefox-extension-v${{ steps.version.outputs.version }}
         path: dist/yt-gemini-summarizer-firefox-v${{ steps.version.outputs.version }}.zip
+        retention-days: 30
+
+    - name: Submit listed version to AMO
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_to_amo }}
+      env:
+        AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
+        AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
+        RELEASE_NOTES: ${{ inputs.release_notes }}
+      run: |
+        set -euo pipefail
+
+        if [ -z "${AMO_JWT_ISSUER}" ] || [ -z "${AMO_JWT_SECRET}" ]; then
+          echo "::error::AMO_JWT_ISSUER and AMO_JWT_SECRET repository secrets are required to publish to AMO."
+          exit 1
+        fi
+
+        metadata_args=()
+        if [ -n "${RELEASE_NOTES}" ]; then
+          python3 -c 'import json, os; json.dump({"release_notes": {"en-US": os.environ["RELEASE_NOTES"]}}, open("amo-metadata.json", "w", encoding="utf-8"), ensure_ascii=False)'
+          metadata_args+=(--amo-metadata=amo-metadata.json)
+        fi
+
+        web-ext sign \
+          --source-dir=. \
+          --artifacts-dir=./signed \
+          --ignore-files=README.md,LICENSE,.github/ \
+          --channel=listed \
+          --api-key="$AMO_JWT_ISSUER" \
+          --api-secret="$AMO_JWT_SECRET" \
+          --approval-timeout=0 \
+          --no-input \
+          "${metadata_args[@]}"
+
+    - name: Upload signed Firefox extension artifact if available
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_to_amo }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: signed-firefox-extension-v${{ steps.version.outputs.version }}
+        path: signed/
+        if-no-files-found: ignore
         retention-days: 30
         
     - name: Upload build summary

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Build artifacts
 dist/
+signed/
 test-dist/
 *.zip
 

--- a/README.md
+++ b/README.md
@@ -173,6 +173,24 @@ Every push to the main branch and pull request triggers our CI/CD pipeline that:
 3. **Creates** a ready-to-install Firefox ZIP file
 4. **Uploads** artifacts for easy download
 
+### Publishing to Firefox Add-ons
+
+Publishing to [addons.mozilla.org](https://addons.mozilla.org/) is available from the manual "Package Firefox Extension" workflow.
+
+Before publishing, add these repository secrets from your AMO API credentials:
+
+- `AMO_JWT_ISSUER`: the AMO API key / JWT issuer
+- `AMO_JWT_SECRET`: the AMO API secret / JWT secret
+
+To publish a new listed version:
+
+1. Bump `version` in `manifest.json`.
+2. Go to the [Actions tab](../../actions) and run the "Package Firefox Extension" workflow manually.
+3. Enable `publish_to_amo`.
+4. Optionally provide `release_notes` to send to AMO.
+
+The workflow submits the listed version with `web-ext sign`. AMO may still run validation or review before the version is public.
+
 ### Download Pre-built Extensions
 
 Instead of building manually, you can download pre-built extension packages:

--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,10 @@
   "description": "Opens Gemini in sidebar to summarize YouTube videos.",
   "browser_specific_settings": {
     "gecko": {
-      "id": "{5dad0765-f81a-42f5-9072-a66dca31efae}"
+      "id": "{5dad0765-f81a-42f5-9072-a66dca31efae}",
+      "data_collection_permissions": {
+        "required": ["none"]
+      }
     }
   },
   "icons": {


### PR DESCRIPTION
Declare that the extension does not collect data using Firefox AMO data collection metadata. Add a guarded manual workflow path that can submit listed versions to AMO with web-ext sign using repository secrets, plus documentation for the release process.