### PR TITLE
Add agent-accessible release workflow

### DIFF
--- a/.github/RELEASE_WORKFLOW.md
+++ b/.github/RELEASE_WORKFLOW.md
@@ -1,0 +1,102 @@
+# Release workflow
+
+This repo uses a two-step release process so humans and agents can prepare releases without directly editing `manifest.json` by hand, while AMO publishing remains tied to a committed and tagged version.
+
+## 1. Prepare a release PR
+
+Trigger the workflow with structured inputs:
+
+```bash
+gh workflow run prepare-release.yml \
+  --ref main \
+  -f bump=patch \
+  -f release_notes="Release notes for AMO and GitHub."
+```
+
+Valid `bump` values:
+
+| Bump | Example |
+| --- | --- |
+| `patch` | `1.5.0` -> `1.5.1` |
+| `minor` | `1.5.0` -> `1.6.0` |
+| `major` | `1.5.0` -> `2.0.0` |
+
+The workflow normalizes two-part versions like `1.5` into three-part releases when bumping, so the next patch release is `1.5.1`.
+
+Monitor the workflow:
+
+```bash
+RUN_ID=$(gh run list \
+  --workflow "Prepare Release" \
+  --event workflow_dispatch \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')
+
+gh run watch "$RUN_ID" --exit-status
+```
+
+Find the release PR:
+
+```bash
+gh pr list \
+  --state open \
+  --base main \
+  --json number,title,headRefName,url \
+  --jq '.[] | select(.headRefName | startswith("release/v"))'
+```
+
+The release PR includes:
+
+- `manifest.json` version bump
+- `release-notes/vX.Y.Z.md` when release notes were provided
+
+## 2. Merge the release PR
+
+Review the release PR, then merge it:
+
+```bash
+gh pr merge <pr-number> --squash --delete-branch
+```
+
+## 3. Publish from an annotated tag
+
+After the release PR is merged:
+
+```bash
+git fetch origin main
+git switch main
+git pull --ff-only origin main
+VERSION=$(python3 -c 'import json; print(json.load(open("manifest.json", encoding="utf-8"))["version"])')
+git tag -a "v${VERSION}" -m "Release v${VERSION}"
+git push origin "v${VERSION}"
+```
+
+The `Package Firefox Extension` workflow publishes to AMO only from `v*` tags. It verifies:
+
+- the tag name matches `manifest.json.version`
+- the tag is annotated
+- the tagged commit is already on `origin/main`
+- AMO credentials are configured as GitHub Actions secrets
+
+Monitor publishing:
+
+```bash
+RUN_ID=$(gh run list \
+  --workflow "Package Firefox Extension" \
+  --event push \
+  --limit 1 \
+  --json databaseId \
+  --jq '.[0].databaseId')
+
+gh run watch "$RUN_ID" --exit-status
+```
+
+If AMO accepts the submission but the listed version is still pending review, the workflow can complete without a signed artifact. The AMO listing remains the source of truth for public availability.
+
+## Required secrets
+
+Add these repository secrets before publishing:
+
+- `AMO_JWT_ISSUER`
+- `AMO_JWT_SECRET`

--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -3,19 +3,14 @@ name: Package Firefox Extension
 on:
   push:
     branches: [ main, master ]
+    tags:
+      - 'v*'
   pull_request:
     branches: [ main, master ]
   workflow_dispatch:
-    inputs:
-      publish_to_amo:
-        description: Submit this version to addons.mozilla.org after packaging
-        required: false
-        default: false
-        type: boolean
-      release_notes:
-        description: Optional AMO release notes for this version
-        required: false
-        type: string
+
+permissions:
+  contents: read
 
 jobs:
   package:
@@ -24,6 +19,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
       
     - name: Setup Node.js
       uses: actions/setup-node@v4
@@ -36,9 +33,34 @@ jobs:
     - name: Get extension version
       id: version
       run: |
-        VERSION=$(grep -o '"version": "[^"]*"' manifest.json | grep -o '[0-9.]*')
+        VERSION=$(python3 -c 'import json; print(json.load(open("manifest.json", encoding="utf-8"))["version"])')
         echo "version=$VERSION" >> $GITHUB_OUTPUT
         echo "Extension version: $VERSION"
+
+    - name: Validate release tag
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+      run: |
+        set -euo pipefail
+
+        TAG_VERSION="${GITHUB_REF_NAME#v}"
+        MANIFEST_VERSION="${{ steps.version.outputs.version }}"
+
+        if [ "$TAG_VERSION" != "$MANIFEST_VERSION" ]; then
+          echo "::error::Tag ${GITHUB_REF_NAME} does not match manifest version ${MANIFEST_VERSION}."
+          exit 1
+        fi
+
+        TAG_OBJECT_TYPE=$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")
+        if [ "$TAG_OBJECT_TYPE" != "tag" ]; then
+          echo "::error::Release tags must be annotated tags. Create one with: git tag -a ${GITHUB_REF_NAME} -m 'Release ${GITHUB_REF_NAME}'"
+          exit 1
+        fi
+
+        git fetch origin main --prune
+        if ! git merge-base --is-ancestor "$GITHUB_SHA" origin/main; then
+          echo "::error::Release tag ${GITHUB_REF_NAME} must point to a commit already merged into origin/main."
+          exit 1
+        fi
         
     - name: Lint extension
       run: |
@@ -68,11 +90,11 @@ jobs:
         retention-days: 30
 
     - name: Submit listed version to AMO
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_to_amo }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       env:
         AMO_JWT_ISSUER: ${{ secrets.AMO_JWT_ISSUER }}
         AMO_JWT_SECRET: ${{ secrets.AMO_JWT_SECRET }}
-        RELEASE_NOTES: ${{ inputs.release_notes }}
+        RELEASE_NOTES_FILE: release-notes/v${{ steps.version.outputs.version }}.md
       run: |
         set -euo pipefail
 
@@ -82,8 +104,8 @@ jobs:
         fi
 
         metadata_args=()
-        if [ -n "${RELEASE_NOTES}" ]; then
-          python3 -c 'import json, os; json.dump({"release_notes": {"en-US": os.environ["RELEASE_NOTES"]}}, open("amo-metadata.json", "w", encoding="utf-8"), ensure_ascii=False)'
+        if [ -s "${RELEASE_NOTES_FILE}" ]; then
+          python3 -c 'import json, os, pathlib; notes = pathlib.Path(os.environ["RELEASE_NOTES_FILE"]).read_text(encoding="utf-8"); json.dump({"release_notes": {"en-US": notes}}, open("amo-metadata.json", "w", encoding="utf-8"), ensure_ascii=False)'
           metadata_args+=(--amo-metadata=amo-metadata.json)
         fi
 
@@ -99,7 +121,7 @@ jobs:
           "${metadata_args[@]}"
 
     - name: Upload signed Firefox extension artifact if available
-      if: ${{ github.event_name == 'workflow_dispatch' && inputs.publish_to_amo }}
+      if: ${{ startsWith(github.ref, 'refs/tags/v') }}
       uses: actions/upload-artifact@v4
       with:
         name: signed-firefox-extension-v${{ steps.version.outputs.version }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,190 @@
+name: Prepare Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump type
+        required: true
+        default: patch
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+      release_notes:
+        description: Optional AMO/GitHub release notes
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install web-ext
+        run: npm install -g web-ext
+
+      - name: Compute next version
+        id: version
+        env:
+          BUMP: ${{ inputs.bump }}
+          RELEASE_NOTES: ${{ inputs.release_notes }}
+        run: |
+          set -euo pipefail
+
+          python3 <<'PY'
+          import json
+          import os
+          import pathlib
+          import re
+
+          manifest_path = pathlib.Path("manifest.json")
+          manifest_text = manifest_path.read_text(encoding="utf-8")
+          manifest = json.loads(manifest_text)
+          current = manifest["version"]
+          bump = os.environ["BUMP"]
+
+          parts = current.split(".")
+          if len(parts) not in (2, 3):
+              raise SystemExit(f"Expected a 2- or 3-part version, got {current!r}")
+
+          parsed = []
+          for part in parts:
+              if not re.fullmatch(r"0|[1-9][0-9]*", part):
+                  raise SystemExit(f"Invalid version part {part!r} in {current!r}")
+              value = int(part)
+              if value > 65535:
+                  raise SystemExit(f"Version part {part!r} exceeds 65535")
+              parsed.append(value)
+
+          while len(parsed) < 3:
+              parsed.append(0)
+
+          major, minor, patch = parsed
+          if bump == "major":
+              major, minor, patch = major + 1, 0, 0
+          elif bump == "minor":
+              minor, patch = minor + 1, 0
+          elif bump == "patch":
+              patch += 1
+          else:
+              raise SystemExit(f"Unknown bump type: {bump}")
+
+          for value in (major, minor, patch):
+              if value > 65535:
+                  raise SystemExit(f"Next version part {value} exceeds 65535")
+
+          next_version = f"{major}.{minor}.{patch}"
+          next_tuple = (major, minor, patch)
+          current_tuple = tuple(parsed)
+          if next_tuple <= current_tuple:
+              raise SystemExit(f"Next version {next_version} must be greater than {current}")
+
+          updated_text, replacements = re.subn(
+              r'("version"\s*:\s*")[^"]+(")',
+              rf"\g<1>{next_version}\2",
+              manifest_text,
+              count=1,
+          )
+          if replacements != 1:
+              raise SystemExit("Could not update manifest.json version")
+          manifest_path.write_text(updated_text, encoding="utf-8")
+
+          release_notes = os.environ.get("RELEASE_NOTES", "").strip()
+          if release_notes:
+              notes_dir = pathlib.Path("release-notes")
+              notes_dir.mkdir(exist_ok=True)
+              notes_path = notes_dir / f"v{next_version}.md"
+              notes_path.write_text(release_notes + "\n", encoding="utf-8")
+
+          github_output = pathlib.Path(os.environ["GITHUB_OUTPUT"])
+          with github_output.open("a", encoding="utf-8") as output:
+              output.write(f"version={next_version}\n")
+              output.write(f"branch=release/v{next_version}\n")
+
+          pathlib.Path("release.env").write_text(
+              f"VERSION={next_version}\nBRANCH=release/v{next_version}\n",
+              encoding="utf-8",
+          )
+          PY
+
+          source release.env
+          rm release.env
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "::error::Release branch ${BRANCH} already exists."
+            exit 1
+          fi
+
+          if git ls-remote --exit-code --tags origin "v${VERSION}" >/dev/null 2>&1; then
+            echo "::error::Release tag v${VERSION} already exists."
+            exit 1
+          fi
+
+      - name: Validate release build
+        run: |
+          set -euo pipefail
+          web-ext lint --source-dir=. --ignore-files=README.md,LICENSE,.github/
+          rm -rf dist
+          web-ext build --source-dir=. --artifacts-dir=./dist --ignore-files=README.md,LICENSE,.github/ --overwrite-dest
+          rm -rf dist
+
+      - name: Create release pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: ${{ steps.version.outputs.version }}
+          BRANCH: ${{ steps.version.outputs.branch }}
+        run: |
+          set -euo pipefail
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git switch -c "$BRANCH"
+          git add manifest.json
+          if [ -d release-notes ]; then
+            git add release-notes/
+          fi
+          git commit -m "Prepare release v${VERSION}"
+          git push --set-upstream origin "$BRANCH"
+
+          cat > pr-body.md <<EOF
+          Prepare release v${VERSION}.
+
+          After this PR is merged, publish by creating an annotated tag:
+
+          \`\`\`bash
+          git fetch origin main
+          git switch main
+          git pull --ff-only origin main
+          git tag -a v${VERSION} -m "Release v${VERSION}"
+          git push origin v${VERSION}
+          \`\`\`
+          EOF
+
+          PR_URL=$(gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Release v${VERSION}" \
+            --body-file pr-body.md)
+
+          echo "Release PR: ${PR_URL}"
+          {
+            echo "## Release PR"
+            echo "${PR_URL}"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Every push to the main branch and pull request triggers our CI/CD pipeline that:
 
 ### Publishing to Firefox Add-ons
 
-Publishing to [addons.mozilla.org](https://addons.mozilla.org/) is available from the manual "Package Firefox Extension" workflow.
+Publishing to [addons.mozilla.org](https://addons.mozilla.org/) is handled by the release workflow documented in [`.github/RELEASE_WORKFLOW.md`](.github/RELEASE_WORKFLOW.md).
 
 Before publishing, add these repository secrets from your AMO API credentials:
 
@@ -184,12 +184,11 @@ Before publishing, add these repository secrets from your AMO API credentials:
 
 To publish a new listed version:
 
-1. Bump `version` in `manifest.json`.
-2. Go to the [Actions tab](../../actions) and run the "Package Firefox Extension" workflow manually.
-3. Enable `publish_to_amo`.
-4. Optionally provide `release_notes` to send to AMO.
+1. Run the "Prepare Release" workflow with a `patch`, `minor`, or `major` bump.
+2. Review and merge the generated release PR.
+3. Create and push the annotated `vX.Y.Z` tag from the merged `main` commit.
 
-The workflow submits the listed version with `web-ext sign`. AMO may still run validation or review before the version is public.
+The tag-triggered package workflow submits the listed version with `web-ext sign`. AMO may still run validation or review before the version is public.
 
 ### Download Pre-built Extensions
 


### PR DESCRIPTION
## Summary
- add a `Prepare Release` workflow that opens a release PR from structured `patch`/`minor`/`major` inputs
- move AMO publishing to annotated `v*` tags that must match `manifest.json.version` and point at `origin/main`
- document the CLI-friendly release flow for humans and AI agents

## Validation
- parsed both workflow YAML files
- ran `web-ext lint`
- ran `web-ext build`
- simulated the patch bump from `1.5` to `1.5.1`