### PR TITLE
Fix release tag validation in Actions

### DIFF
--- a/.github/workflows/package-extension.yml
+++ b/.github/workflows/package-extension.yml
@@ -50,9 +50,16 @@ jobs:
           exit 1
         fi
 
+        git fetch --force origin "refs/tags/${GITHUB_REF_NAME}:refs/tags/${GITHUB_REF_NAME}"
         TAG_OBJECT_TYPE=$(git cat-file -t "refs/tags/${GITHUB_REF_NAME}")
         if [ "$TAG_OBJECT_TYPE" != "tag" ]; then
           echo "::error::Release tags must be annotated tags. Create one with: git tag -a ${GITHUB_REF_NAME} -m 'Release ${GITHUB_REF_NAME}'"
+          exit 1
+        fi
+
+        TAG_TARGET_SHA=$(git rev-parse "refs/tags/${GITHUB_REF_NAME}^{}")
+        if [ "$TAG_TARGET_SHA" != "$GITHUB_SHA" ]; then
+          echo "::error::Release tag ${GITHUB_REF_NAME} points to ${TAG_TARGET_SHA}, but this workflow is running for ${GITHUB_SHA}."
           exit 1
         fi
 


### PR DESCRIPTION
## Summary
- force-fetch the pushed release tag before checking whether it is annotated
- verify the annotated tag peels to the workflow commit before allowing AMO publishing

## Why
The `v1.5.1` tag is annotated, but `actions/checkout` created a local tag ref that looked like a lightweight tag in the workflow checkout. This caused release validation to fail before AMO submission.

## Validation
- parsed the package workflow YAML
- ran `web-ext lint`
- ran `web-ext build`
- simulated a GitHub Actions checkout with a lightweight local tag ref and confirmed the fixed validation fetches the annotated remote tag correctly